### PR TITLE
Fix compilation overrides for ERC20

### DIFF
--- a/FlameBornToken.sol
+++ b/FlameBornToken.sol
@@ -62,41 +62,5 @@ contract FlameBornToken is
         super._update(from, to, value);
     }
 
-    // Override required by Solidity for multiple inheritance
-    function _beforeTokenTransfer(address from, address to, uint256 amount)
-        internal
-        override(ERC20, ERC20Pausable)
-    {
-        super._beforeTokenTransfer(from, to, amount);
-    }
 
-    function _afterTokenTransfer(address from, address to, uint256 amount)
-        internal
-        override(ERC20, ERC20Votes)
-    {
-        super._afterTokenTransfer(from, to, amount);
-    }
-
-    function _mint(address to, uint256 amount)
-        internal
-        override(ERC20, ERC20Votes)
-    {
-        super._mint(to, amount);
-    }
-
-    function _burn(address account, uint256 amount)
-        internal
-        override(ERC20, ERC20Votes)
-    {
-        super._burn(account, amount);
-    }
-
-    function nonces(address owner)
-        public
-        view
-        override(ERC20Permit)
-        returns (uint256)
-    {
-        return super.nonces(owner);
-    }
 }


### PR DESCRIPTION
## Summary
- remove obsolete override functions
- keep only the `_update` override required for multiple inheritance

## Testing
- `N/A`

------
https://chatgpt.com/codex/tasks/task_e_68490cb227e883249b232a282e87d6a9